### PR TITLE
Dynamically get expected menu position in DOM

### DIFF
--- a/js/usermenu.js
+++ b/js/usermenu.js
@@ -38,10 +38,11 @@
   function injectUserMenuInAMainMenuWrapper (menuMarkup, wrapperId) {
     var $menuMarkup = $(menuMarkup);
     var $menuWrapper = $('<div>');
+    var prevSibling = CRM.$('#civicrm-menu-nav').prev();
 
     $menuWrapper.attr('id', wrapperId);
     $menuWrapper.append($('#civicrm-menu-nav'));
     $menuWrapper.append($menuMarkup);
-    $menuWrapper.insertAfter('#page');
+    $menuWrapper.insertAfter(prevSibling);
   }
 }(CRM.$, CRM._, ts));


### PR DESCRIPTION
Overview
Fix https://github.com/compucorp/uk.co.compucorp.usermenu/issues/13.

Before
The CiviCRM menu is removed.

After
The CiviCRM menu is still ere, and userMenu inside it.

Technical Details
For example, in WordPress installation, CRM.$('#page') do not exists, so the $('#civicrm-menu-nav') was inserted nowhere.